### PR TITLE
Wrap custom component in div

### DIFF
--- a/src/components/RequestAccessSection.tsx
+++ b/src/components/RequestAccessSection.tsx
@@ -115,7 +115,9 @@ export default function RequestAccessSection({ sx }: { sx?: SxProps<Theme> }) {
               justifyContent: "center",
             }}
           >
-            <CredentialCard operatorType={tab} cred={cred ?? undefined} />
+            <div>
+              <CredentialCard operatorType={tab} cred={cred ?? undefined} />
+            </div>
           </Modal>
         </Box>
       </Stack>


### PR DESCRIPTION
Fixes #125 

This PR simply wraps the `CredentialCard` component in a `div`, when it's the child of the `Modal` which was producing the browser console error.

The error no longer appears after these changes.