### PR TITLE
Add OperatorInfo Component and Hook

### DIFF
--- a/src/Api.tsx
+++ b/src/Api.tsx
@@ -49,8 +49,8 @@ export interface QuotaSettings {
 // Unix timestamps and quota settings for the corresponding operator are returned.
 // Returns up to the maximum # of allowed credentials from the most recent
 // sliding 'window', or returns an empty array if the operator has not
-// requested any credentials within that timeframe. Quota settings are always
-// returned.
+// requested any credentials within that timeframe. Credential events are in
+// descending order (newest to oldest). Quota settings are always returned.
 export interface OperatorInfo {
   credentialEvents: number[];
   quotaSettings: QuotaSettings;

--- a/src/Api.tsx
+++ b/src/Api.tsx
@@ -35,14 +35,46 @@ export interface AccessCredential {
   expiresAt: number;
 }
 
+// Quota settings for a given operator, based on operator type
+// count = total # times per sliding 'window' that access can be requested
+// window = sliding 'window' duration measured in seconds
+// authValidityWindow = credential validity lifetime measured in seconds
+export interface QuotaSettings {
+  count: number;
+  window: number;
+  authValidityWindow: number;
+}
+
+// When requesting OperatorInfo, an array of past credential request event
+// Unix timestamps and quota settings for the corresponding operator are returned.
+// Returns up to the maximum # of allowed credentials from the most recent
+// sliding 'window', or returns an empty array if the operator has not
+// requested any credentials within that timeframe. Quota settings are always
+// returned.
+export interface OperatorInfo {
+  credentialEvents: number[];
+  quotaSettings: QuotaSettings;
+}
+
 export const Api: {
   createCredentials: ApiMethod<AccessCredential>;
+  getOperatorInfo: ApiMethod<OperatorInfo>;
   // Other methods
 } = {
   createCredentials: async (params, onData, onError, onComplete) => {
     await rpc<AccessCredential>(
       "POST",
       "/credentials",
+      params,
+      onData,
+      onError,
+      onComplete,
+    );
+  },
+  getOperatorInfo: async (params, onData, onError, onComplete) => {
+    await rpc<OperatorInfo>(
+      "POST",
+      "/info",
       params,
       onData,
       onError,

--- a/src/components/OperatorInfoAlert.tsx
+++ b/src/components/OperatorInfoAlert.tsx
@@ -1,7 +1,6 @@
 import { Alert, Typography } from "@mui/material";
 import useIsValidSignedMessage from "../hooks/useIsValidSignedMessage";
 import { OperatorInfo } from "../Api";
-import { useState } from "react";
 import useGetOperatorInfo from "../hooks/useGetOperatorInfo";
 
 export default function OperatorInfoAlert({
@@ -12,17 +11,11 @@ export default function OperatorInfoAlert({
   operatorType: "solo" | "rocketpool";
 }) {
   const { data: isValid } = useIsValidSignedMessage(signedMessage);
-  const [opInfo, setOpInfo] = useState<OperatorInfo | null>(null);
-  const onError = (error: string) => {
-    console.log(error);
-  };
 
-  useGetOperatorInfo({
+  let { data: opInfo } = useGetOperatorInfo({
     signedMessage: signedMessage,
     operatorType: operatorType,
     enabled: !!isValid,
-    onData: setOpInfo,
-    onError: onError,
   });
 
   if (!opInfo || !isValid) {

--- a/src/components/OperatorInfoAlert.tsx
+++ b/src/components/OperatorInfoAlert.tsx
@@ -11,9 +11,11 @@ export default function OperatorInfoAlert({
   signedMessage: string;
   operatorType: "solo" | "rocketpool";
 }) {
-  const { data: isValid } = useIsValidSignedMessage(signedMessage)
+  const { data: isValid } = useIsValidSignedMessage(signedMessage);
   const [opInfo, setOpInfo] = useState<OperatorInfo | null>(null);
-  const onError = (error: string) => { console.log(error)}
+  const onError = (error: string) => {
+    console.log(error);
+  };
 
   useGetOperatorInfo({
     signedMessage: signedMessage,
@@ -28,7 +30,10 @@ export default function OperatorInfoAlert({
   }
 
   return (
-    <Alert severity="info" sx={{ display: "flex", alignItems: "center", mt: 2 }}>
+    <Alert
+      severity="info"
+      sx={{ display: "flex", alignItems: "center", mt: 2 }}
+    >
       <Typography sx={{ mr: 2, whiteSpace: "pre-line" }} variant="body2">
         {getQuotaText({ operatorInfo: opInfo })}
       </Typography>
@@ -46,8 +51,8 @@ function getQuotaText({ operatorInfo }: { operatorInfo: OperatorInfo }) {
   const used = operatorInfo.credentialEvents.length;
   const remaining =
     operatorInfo.quotaSettings.count - operatorInfo.credentialEvents.length;
-    
-  // tz is in locale string format, e.g. 'America/New_York' 
+
+  // tz is in locale string format, e.g. 'America/New_York'
   const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
   var usageMsg = `You have not used the Rescue Node in the past ${windowInDays} days.`;
   var activeCredMsg = `You do not currently have an active credential.`;

--- a/src/components/OperatorInfoAlert.tsx
+++ b/src/components/OperatorInfoAlert.tsx
@@ -1,0 +1,84 @@
+import { Alert, Typography } from "@mui/material";
+import useIsValidSignedMessage from "../hooks/useIsValidSignedMessage";
+import { OperatorInfo } from "../Api";
+import { useState } from "react";
+import useGetOperatorInfo from "../hooks/useGetOperatorInfo";
+
+export default function OperatorInfoAlert({
+  signedMessage,
+  operatorType,
+}: {
+  signedMessage: string;
+  operatorType: "solo" | "rocketpool";
+}) {
+  const { data: isValid } = useIsValidSignedMessage(signedMessage)
+  const [opInfo, setOpInfo] = useState<OperatorInfo | null>(null);
+  const onError = (error: string) => { console.log(error)}
+
+  useGetOperatorInfo({
+    signedMessage: signedMessage,
+    operatorType: operatorType,
+    enabled: !!isValid,
+    onData: setOpInfo,
+    onError: onError,
+  });
+
+  if (!opInfo) {
+    return null;
+  }
+
+  return (
+    <Alert severity="info" sx={{ display: "flex", alignItems: "center", mt: 2 }}>
+      <Typography sx={{ mr: 2, whiteSpace: "pre-line" }} variant="body2">
+        {getQuotaText({ operatorInfo: opInfo })}
+      </Typography>
+    </Alert>
+  );
+}
+
+function getQuotaText({ operatorInfo }: { operatorInfo: OperatorInfo }) {
+  if (operatorInfo === null) {
+    return null;
+  }
+
+  // 86400 seconds = 1 day
+  const windowInDays = operatorInfo.quotaSettings.window / 86400;
+  const used = operatorInfo.credentialEvents.length;
+  const remaining =
+    operatorInfo.quotaSettings.count - operatorInfo.credentialEvents.length;
+    
+  // tz is in locale string format, e.g. 'America/New_York' 
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  var usageMsg = `You have not used the Rescue Node in the past ${windowInDays} days.`;
+  var activeCredMsg = `You do not currently have an active credential.`;
+  var remainingMsg = `You have ${remaining} usages remaining.`;
+
+  if (used > 0) {
+    // Multiplying by 1000 converts timestamp to milliseconds for working with Date()
+    const nextTimestamp =
+      operatorInfo.credentialEvents[operatorInfo.credentialEvents.length - 1] *
+        1000 +
+      operatorInfo.quotaSettings.window * 1000 +
+      1000;
+    const nextDate = new Date(nextTimestamp).toLocaleString("en-US", {
+      timeZone: tz,
+    });
+    const expiresTimestamp =
+      operatorInfo.credentialEvents[0] * 1000 +
+      operatorInfo.quotaSettings.authValidityWindow * 1000;
+    const expiresDate = new Date(expiresTimestamp).toLocaleString("en-US", {
+      timeZone: tz,
+    });
+
+    usageMsg = `You have used the Rescue Node ${used} times in the past ${windowInDays} days.`;
+    remainingMsg = `You have ${remaining} usages remaining. Your next increase will be at ${nextDate} (${tz}).`;
+
+    if (expiresTimestamp > Date.now()) {
+      activeCredMsg = `You currently have an active credential, which will expire at ${expiresDate} (${tz}).`;
+    }
+  }
+
+  return `${usageMsg}
+  ${activeCredMsg}
+  ${remainingMsg}`;
+}

--- a/src/components/SignedMessageForm.tsx
+++ b/src/components/SignedMessageForm.tsx
@@ -13,6 +13,7 @@ import {
 } from "@mui/material";
 import { Error, HourglassEmpty } from "@mui/icons-material";
 import { type AccessCredential, Api } from "../Api";
+import OperatorInfoAlert from "./OperatorInfoAlert";
 
 // A form for submitting the signed message JSON.
 //
@@ -94,6 +95,7 @@ export default function SignedMessageForm({
           4,
         )}
       />
+      <OperatorInfoAlert signedMessage={value} operatorType={operatorType} />
       <FormControlLabel
         sx={{ mt: 1, mb: 1 }}
         control={

--- a/src/hooks/useGetOperatorInfo.tsx
+++ b/src/hooks/useGetOperatorInfo.tsx
@@ -1,0 +1,39 @@
+import { useQuery } from "wagmi";
+import { Api, OperatorInfo } from "../Api"
+
+// Hook to retrieve OperatorInfo from API
+export default function useGetOperatorInfo({
+  signedMessage,
+  operatorType,
+  enabled,
+  onData,
+  onError,
+  onSuccess,
+}: {
+  signedMessage: string,
+  operatorType: "solo" | "rocketpool",
+  enabled: boolean
+  onData: (data: OperatorInfo) => void
+  onError: (error: string) => void
+  onSuccess?: () => void
+}) {
+  return useQuery<boolean, Error>(
+    ["Api.getOperatorInfo", signedMessage, operatorType],
+    async () => { 
+        try { 
+          await Api.getOperatorInfo(
+            { body: signedMessage, query: { operator_type: operatorType } },
+            onData, onError, onSuccess ? onSuccess : () => {}
+          )
+          return true
+        }
+        catch(e) {
+          console.log("Error retrieving operator info:", e)
+          return false
+        }
+    },
+    {
+      enabled: enabled
+    },
+  );
+}

--- a/src/hooks/useGetOperatorInfo.tsx
+++ b/src/hooks/useGetOperatorInfo.tsx
@@ -6,32 +6,27 @@ export default function useGetOperatorInfo({
   signedMessage,
   operatorType,
   enabled,
-  onData,
-  onError,
-  onSuccess,
 }: {
   signedMessage: string;
   operatorType: "solo" | "rocketpool";
   enabled: boolean;
-  onData: (data: OperatorInfo) => void;
-  onError: (error: string) => void;
-  onSuccess?: () => void;
 }) {
-  return useQuery<boolean, Error>(
+  return useQuery<OperatorInfo, Error>(
     ["Api.getOperatorInfo", signedMessage, operatorType],
     async () => {
-      try {
-        await Api.getOperatorInfo(
-          { body: signedMessage, query: { operator_type: operatorType } },
-          onData,
-          onError,
-          onSuccess ? onSuccess : () => {},
-        );
-        return true;
-      } catch (e) {
-        console.log("Error retrieving operator info:", e);
-        return false;
+      let error: string | undefined;
+      let data: OperatorInfo | undefined;
+      await Api.getOperatorInfo(
+        { body: signedMessage, query: { operator_type: operatorType } },
+        (d) => (data = d),
+        (e) => (error = e),
+        () => {},
+      );
+
+      if (error) {
+        throw new Error(error);
       }
+      return data!;
     },
     {
       enabled: enabled,

--- a/src/hooks/useGetOperatorInfo.tsx
+++ b/src/hooks/useGetOperatorInfo.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "wagmi";
-import { Api, OperatorInfo } from "../Api"
+import { Api, OperatorInfo } from "../Api";
 
 // Hook to retrieve OperatorInfo from API
 export default function useGetOperatorInfo({
@@ -10,30 +10,31 @@ export default function useGetOperatorInfo({
   onError,
   onSuccess,
 }: {
-  signedMessage: string,
-  operatorType: "solo" | "rocketpool",
-  enabled: boolean
-  onData: (data: OperatorInfo) => void
-  onError: (error: string) => void
-  onSuccess?: () => void
+  signedMessage: string;
+  operatorType: "solo" | "rocketpool";
+  enabled: boolean;
+  onData: (data: OperatorInfo) => void;
+  onError: (error: string) => void;
+  onSuccess?: () => void;
 }) {
   return useQuery<boolean, Error>(
     ["Api.getOperatorInfo", signedMessage, operatorType],
-    async () => { 
-        try { 
-          await Api.getOperatorInfo(
-            { body: signedMessage, query: { operator_type: operatorType } },
-            onData, onError, onSuccess ? onSuccess : () => {}
-          )
-          return true
-        }
-        catch(e) {
-          console.log("Error retrieving operator info:", e)
-          return false
-        }
+    async () => {
+      try {
+        await Api.getOperatorInfo(
+          { body: signedMessage, query: { operator_type: operatorType } },
+          onData,
+          onError,
+          onSuccess ? onSuccess : () => {},
+        );
+        return true;
+      } catch (e) {
+        console.log("Error retrieving operator info:", e);
+        return false;
+      }
     },
     {
-      enabled: enabled
+      enabled: enabled,
     },
   );
 }


### PR DESCRIPTION
Adds an OperatorInfo component and hook to automatically query the Rescue API '/info' endpoint when a valid signed message is entered into the SignedMessageForm. Credential usage and quota information is automatically retrieved and displayed for the respective operator. This provides helpful context before the operator submits a credential request.

Works for both RP and Solo node types.

Displays:
- Number of uses redeemed in current credential window (e.g. 0-4 uses within past 365 days)
- Currently active credentials (if any) (credential values not displayed), with localized expiration date and time, and locale string
- Number of uses remaining, with localized date and time of next usage increase, and locale string

This is a significantly simplified re-submission of my previous PR.

RP Node Example:
![rp-example](https://github.com/user-attachments/assets/adad1bb3-6c25-47f1-aef0-62856dc99b23)

Solo Node Example:
![solo-example](https://github.com/user-attachments/assets/36361eee-4fa4-49c2-b54a-03db90ac50bb)
