### PR TITLE
Typo Update original-tech-spec.md

### DIFF
--- a/docs/src/tech-specs/original-tech-spec.md
+++ b/docs/src/tech-specs/original-tech-spec.md
@@ -94,7 +94,7 @@ The body of this message should contain a known string and a timestamp expressed
 The node operator would paste the message into a web ui or POST it as the body of an API request to the auth token generator.
 
 The API will:
-1. Validated the signature
+1. Validate the signature
 1. Ensure that the timestamp is "recent"
 1. Ensure that the node is not banned for misbehavior
 1. Determine if a credential younger than GRACE_PERIOD_DAYS already exists, and if so, return it. If a credential between GRACE_PERIOD_DAYS and (GRACE_PERIOD_DAYS + TIMEOUT_DAYS) exists, reject access to the rescue node.


### PR DESCRIPTION
**Description**:
This pull request addresses a minor typographical error found in the documentation. 

### Original:
```markdown
1. Validated the signature
```

### Issue:
The word "Validated" is incorrectly used in the past tense. In this context, the correct form should be "Validate" to maintain parallel structure and consistency with the other steps in the list, which are written in the present tense.

### Corrected:
```markdown
1. Validate the signature
```

This change ensures the list maintains a consistent and grammatically correct present tense format, improving readability and clarity for the users reading the technical steps.

---

This fix enhances the clarity of the documentation and ensures a uniform style, making it easier for users to follow the instructions accurately.

