### PR TITLE
Fix Content-Security-Policy Header Template String Interpolation

### DIFF
--- a/scripts/src/gen_headers.ts
+++ b/scripts/src/gen_headers.ts
@@ -39,6 +39,9 @@ const tmpl: string = `/*
   console.log(
     `Setting /docs/* Content-Security-Policy script-src to \`${scriptSrc}\``,
   );
+  const tmpl = `/*
+    Content-Security-Policy: default-src 'none'; script-src '${scriptSrc}';
+  */`;
 
   await fs.writeFile(out, tmpl.replace("{script_src}", scriptSrc));
 })().catch((err) => {


### PR DESCRIPTION
**Description:**

This update addresses an issue in the dynamic generation of the `Content-Security-Policy` header. In the original implementation, the header's `script-src` directive was not being correctly updated with the computed hashes for inline scripts. The placeholder `{script_src}` was being used within the template, which was not properly replaced with the actual value during execution.

### What's been changed:
- **String Interpolation:** Replaced the placeholder `{script_src}` in the template with `${scriptSrc}` for proper string interpolation. This ensures the dynamically generated `script-src` directive accurately reflects the computed script hashes.
- **Template Update:** After calculating all script hashes, the template is now correctly updated to use the `scriptSrc` value.

### Why it's important:
The proper generation of the `Content-Security-Policy` header is crucial for security, as it defines which sources are allowed to load scripts. By correcting the string interpolation, we ensure that the policy accurately reflects the scripts present on the page, thus improving security by preventing unauthorized or malicious script execution.

This change ensures that the application generates a correct and secure Content-Security-Policy header, which is critical for protecting against XSS (Cross-Site Scripting) attacks and other security vulnerabilities associated with inline scripts.